### PR TITLE
Use qtbase5-dev on Ubuntu Noble

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -28,7 +28,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>qt6-base-dev</build_depend>
+  <build_depend>qtbase5-dev</build_depend>
   <build_depend>python3-qt-bindings</build_depend>
   <build_export_depend>python3-dev</build_export_depend>
 


### PR DESCRIPTION
Select qt5 on Ubuntu Noble

https://build.ros2.org/view/Rbin_uN64/job/Rbin_uN64__qt_gui_cpp__ubuntu_noble_amd64__binary/118

```
14:07:52 -- Modern SIP binding generator NOT available.
14:07:52 CMake Warning at /opt/ros/rolling/share/python_qt_binding/cmake/sip_helper.cmake:38 (message):
14:07:52   Could not determine PyQt6 bindings directory.
14:07:52 Call Stack (most recent call first):
14:07:52   /opt/ros/rolling/share/python_qt_binding/cmake/sip_helper.cmake:79 (__find_qt_sip_files)
14:07:52   src/qt_gui_cpp_sip/CMakeLists.txt:71 (include)
14:07:52 
14:07:52 
14:07:52 CMake Error at /opt/ros/rolling/share/python_qt_binding/cmake/sip_helper.cmake:81 (message):
14:07:52   PyQt6 SIP bindings are required but were not found.
14:07:52 Call Stack (most recent call first):
14:07:52   src/qt_gui_cpp_sip/CMakeLists.txt:71 (include)
```